### PR TITLE
Custom contract revert handling

### DIFF
--- a/contracts/src/FlashLoanHandler.sol
+++ b/contracts/src/FlashLoanHandler.sol
@@ -15,7 +15,7 @@ contract FlashLoanHandler {
     event soldEth(bytes32 indexed flashLoanId, uint256 ethAmount, uint256 chainid, address indexed user);
     event boughtEth(bytes32 indexed flashLoanId, uint256 ethAmount, uint256 chainid, address indexed user);
     event sentProfit(bytes32 indexed flashLoanId, uint256 ethAmount, uint256 chainid, address indexed user);
-    event noProfit();
+    event noProfit(bytes32 indexed flashLoanId, uint256 chainid, address indexed user);
 
     address payable flashBorrowerDefaultAddress;
 
@@ -58,7 +58,7 @@ contract FlashLoanHandler {
         CrossDomainMessageLib.requireMessageSuccess(sendEthMsgHash);
 
         try this.callOnFlashLoan(flashLoanId, caller, flashBorrower){} catch {
-            emit noProfit(); //TODO: Define Proper Events For Failiure
+            //TODO: Define Proper Events For Failiure
         }
         tranferToSourceChain(sourceChain, caller, loanAmount, flashLoanId);
     }
@@ -110,7 +110,7 @@ contract FlashLoanHandler {
         else {
             flashLoanVaultAddress.call {value: address(this).balance} ("");
             emit flashLoanRepayed(flashLoanId, loanAmount, block.chainid, caller);
-            emit noProfit();
+            emit noProfit(flashLoanId, block.chainid, caller);
         }
     }
 


### PR DESCRIPTION
implemented and tested secure functionality for handling misbehaving custom FlashBorrower contracts.

front-end changes:

- you can now call the following function if the user chooses the advanced feature: function callFlashLoanHandlerAdvanced(uint256 destinationChain, address flashBorrowerAddress)
- Call this function if the user does not choose the advanced feature: function callFlashLoanHandler(uint256 destinationChain)

in the scenario that the custom contract is flawed (or in-existent) the sellEth, buyEth, and sentProfit events will not trigger. instead a noProfit even will trigger. so front end needs to set 100% completion at EITHER sentProfit OR noProfit
 
Next steps:

- More security checks for solidity backend and ensure loan payback for all fails
- test different types of custom FlashBorrower contracts
- Refactor! the FlashLoanHandler contract looks ugly.