### PR TITLE
added a working and simple flash loan contract

### DIFF
--- a/contracts/src/SimpleFlashLoan.sol
+++ b/contracts/src/SimpleFlashLoan.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.26;
+
+import "https://github.com/aave/aave-v3-core/blob/master/contracts/flashloan/base/FlashLoanSimpleReceiverBase.sol";
+import "https://github.com/aave/aave-v3-core/blob/master/contracts/interfaces/IPoolAddressesProvider.sol";
+import "https://github.com/aave/aave-v3-core/blob/master/contracts/dependencies/openzeppelin/contracts/IERC20.sol";
+
+contract SimpleFlashLoan is FlashLoanSimpleReceiverBase {
+    address payable owner;
+
+    event Log(string message, uint256 value);
+
+    constructor(
+        address _addressProvider
+    ) FlashLoanSimpleReceiverBase(IPoolAddressesProvider(_addressProvider)) {}
+
+    function fn_RequestFlashLoan(address _token, uint256 _amount) public {
+        address receiverAddress = address(this);
+        address asset = _token;
+        uint256 amount = _amount;
+        bytes memory params = "";
+        uint16 referralCode = 0;
+
+        POOL.flashLoanSimple(
+            receiverAddress,
+            asset,
+            amount,
+            params,
+            referralCode
+        );
+    }
+
+    //This function is called after your contract has received the flash loaned amount
+
+    function executeOperation(
+        address asset,
+        uint256 amount,
+        uint256 premium,
+        address initiator,
+        bytes calldata params
+    ) external override returns (bool) {
+        //Logic goes here
+
+        uint256 totalAmount = amount + premium;
+
+        uint256 balance = IERC20(asset).balanceOf(address(this));
+        emit Log("Balance before repayment", balance);
+        emit Log("Total to repay", totalAmount);
+
+        require(balance >= totalAmount, "Insufficient balance to repay");
+
+        IERC20(asset).approve(address(POOL), totalAmount);
+
+        return true;
+    }
+
+    receive() external payable {}
+}


### PR DESCRIPTION
**How to use it:**
This run example uses aave’s addresses for Ethereum sepolia testnet: https://aave.com/docs/resources/addresses

1. Deploy contract
    - Params:
      - _addressProvider: 0x012bAC54348C0E635dCAc9D5FB99f06F24136C9A
2. Get USDC from Faucet: https://faucet.circle.com/
3. Fund the contract with at least 1 USDC 
4. Execute fn_RequestFlashLoan
    - Params: 
      - _token: 0x94a9D9AC8a22534E3FaCa9F4e7F2E2cf85d5E4C8
      - _amount: 100

Successful flash loan receipt:
https://sepolia.etherscan.io/tx/0xa91389c1e14da3a7131be82f057859af9b8cd1b5ff5a37379159b2e1bd38e5d1
